### PR TITLE
Add build script to top-level.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "install": "cd server && npm i && cd ../client && npm i",
-    "dev": "concurrently \"cd server && npm run dev\" \"cd client && npm start\""
+    "dev": "concurrently \"cd server && npm run dev\" \"cd client && npm start\"",
+    "build": "cd client && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Another oversight! Should have just copied the scripts from our most recent challenge. This update adds another script required by Heroku to the root `package.json`.